### PR TITLE
Add ridge.css

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ To contribute, fork this repository, add your new resource and submit a PR. For 
 * [Alptail: Alpine.js + TailwindCSS Components - Daniel Palmer](https://www.alptail.com/)
 * [Click Speed Test - Luciano Felix](https://codepen.io/FelixLuciano/pen/MWavXmy)
 * [Dynamic Form Fields - Sanjay Ojha](https://codepen.io/sanjayojha/pen/qBONdVm)
+* [Ridge.css - A maximalist css framework with Alpine.js markup - Sean Walker](https://github.com/swlkr/ridgecss)
 
 ## Extensions & Plugins
 


### PR DESCRIPTION
Ridge.css is a css framework tailor made to work with alpine.

Most of the examples show alpine markup and the idea is to grab a component from the growing list of examples directly into your project to maximize development speed